### PR TITLE
Fixed typo in the environment documentation

### DIFF
--- a/docs/apis/environment.md
+++ b/docs/apis/environment.md
@@ -16,7 +16,7 @@ card.services('environment').request('environment')
 Alternatively, this environment information is available on App Card activation:
 
 ```js
-var card = new SW.card();
+var card = new SW.Card();
 card.onActivate(function(environment){
   // see response below
 });


### PR DESCRIPTION
When declaring a new card if card is not capitalized then you get an error about it not being a constructor. Capitalizing it fixed the error and allows you to pull data from the API.