### PR TITLE
Add the ability to set related items on a ticket

### DIFF
--- a/docs/apis/helpdesk.md
+++ b/docs/apis/helpdesk.md
@@ -246,6 +246,7 @@ Name | Type | Description
 `priority`|`string`| The priority of the request. Must be `low`, `med`, or `high`.  Default: `med`.
 `due_at`|`string`| Due date of the request.  Must be a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
 `status`|`string`| The current status of the request. Must be `open` or `closed`.  Default: `open`.
+`inventory_items`|`array`| A list of items from inventory related to the ticket.  Must be an array of objects containing an `id` and a `type` property for a valid inventory item.
 
 ##### Response
 
@@ -276,6 +277,8 @@ Name | Type | Description
 `priority`|`string`| The priority of the request. Must be `low`, `med`, or `high`.  Default: `med`.
 `due_at`|`string`| Due date of the request.  Must be a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.
 `status`|`string`| The current status of the request. Must be `open` or `closed`.  Default: `open`.
+`inventory_items`|`array`| A list of items from inventory related to the ticket.  Must be an array of objects containing an `id` and a `type` property for a valid inventory item.
+
 
 ##### Response
 


### PR DESCRIPTION
When creating or updating a ticket, allow the developer to set the list 
of associated inventory items.