### PR TITLE
updated filters and device output for online. 

### DIFF
--- a/docs/apis/inventory.md
+++ b/docs/apis/inventory.md
@@ -22,9 +22,10 @@ Name | Type | Description
 `id` | `array` | Returns devices whose id is contained within the array of ids.
 `scan_state`|`string`| Return devices that were in this state during the last scan. Can be either `'inventoried'`,  `'offline'`, or `'unknown'`.
 `owner.id`| 'integer' | Return devices owned by the user with id `owner.id`.
-`offline_at`|`object`(datetime range)| Return devices that were offline within the given range.
-`online_at`|`object`(datetime range)| Return devices that were online within the given range.
-`last_scanned_at`|`object`(datetime range)| Return devices that were last scanned within the given range.
+`offline_at`|`object`(datetime range)| Return devices that were last noticed offline within the given datetime range.
+`online_at`|`object`(datetime range)| Return devices that were last noticed online within the given datetime range.
+`online`|`boolean`| Return only devices that are online if `true` or offline if `false`.
+`last_scanned_at`|`object`(datetime range)| Return devices that were last scanned within the given datetime range.
 `operating_system`|`string`| Return devices running the operating system `operating_system`.
 `model`|`string`| Return devices with model name `model`.
 `manufacturer`|`string`| Return devices manufactured by `manufacturer`.
@@ -107,7 +108,7 @@ item):
   "asset_tag": "3B71E7EF7A",
   "serial_number": "3B71E7EF7A",
   "uuid": "332A52FA-6EAF-86A6-3FE1-A340835369B1",
-  "created_at": "2015-02-04T12:56:38-08:00",
+  "created_at": "2015-02-01T12:56:38-08:00",
   "updated_at": "2015-02-19T02:26:01-08:00",
   "scan_state": "inventoried",
   "install_date": "2014-05-30T20:40:42-07:00",
@@ -115,8 +116,9 @@ item):
   "last_boot_up_time": "2015-02-04T10:57:36-08:00",
   "last_qrcode_time": null,
   "last_scan_time": "2015-02-04T13:50:48-08:00",
-  "offline_at": null,
+  "offline_at": "2015-02-02T01:21:31-08:00",
   "online_at": "2015-02-04T13:50:48-08:00",
+  "online": true,
   "up_time": null,
   "owner": null,
   "site": {
@@ -324,6 +326,7 @@ item):
   "last_scan_time": "2015-02-04T17:18:18-06:00",
   "offline_at": null,
   "online_at": "2015-02-04T17:18:18-06:00",
+  "online": true,
   "up_time": null,
   "owner": null,
   "site": {
@@ -423,6 +426,7 @@ Example response for a user-defined asset or an unknown device on the network:
   "last_scan_time": null,
   "offline_at": null,
   "online_at": null,
+  "online": true,
   "up_time": null,
   "owner": null,
   "site": {

--- a/docs/apis/inventory.md
+++ b/docs/apis/inventory.md
@@ -20,7 +20,7 @@ card.services('inventory').request('devices'[, options])
 Name | Type | Description
 -----|------|--------------
 `id` | `array` | Returns devices whose id is contained within the array of ids.
-`scan_state`|`string`| Return devices that were in this state during the last scan. Can be either `'inventoried'`,  `'offline'`, or `'unknown'`.
+`scan_state`|`string`| Return devices that were in this state during the last scan. Can be either `'inventoried'`,  `'manual'`, or `'unknown'`.
 `owner.id`| 'integer' | Return devices owned by the user with id `owner.id`.
 `offline_at`|`object`(datetime range)| Return devices that were last noticed offline within the given datetime range.
 `online_at`|`object`(datetime range)| Return devices that were last noticed online within the given datetime range.


### PR DESCRIPTION
also fixed example output to show that a device can have an offline and online time (online if online time is more recent)